### PR TITLE
Windows: use #![no_std]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Windows
 -------
 In the `windows` directory.
 
-With `x86_64-pc-windows-msvc` the following command creates a 1,536 byte .exe:
-`cargo rustc --release -- -Clink-args="/ENTRY:entry_point /ALIGN:16"`
+With `x86_64-pc-windows-msvc` the following command creates a 1,312 byte .exe:
+`cargo rustc --release -- -Clink-args="/ENTRY:entry_point /ALIGN:16 /SUBSYSTEM:CONSOLE /NODEFAULTLIB"`
 
-This entry has the advantage of using nothing more than stable Rust and still having access to all of libstd.
+This entry requires nightly Rust, but only depends on libcore and kernel32.dll.
 
 Something else
 --------------

--- a/windows/Cargo.toml
+++ b/windows/Cargo.toml
@@ -3,9 +3,5 @@ authors = ["Peter Atashian <retep998@gmail.com>"]
 name = "hello"
 version = "0.1.0"
 
-[dependencies]
-kernel32-sys = "0.2.1"
-winapi = "0.2.5"
-
 [profile.release]
 lto = true

--- a/windows/src/main.rs
+++ b/windows/src/main.rs
@@ -1,12 +1,48 @@
-extern crate winapi;
-extern crate kernel32;
-use std::ptr;
-fn main() {
-    let msg = "Hello world!\n";
-    let stdout = unsafe { kernel32::GetStdHandle(winapi::STD_OUTPUT_HANDLE) };
-    unsafe { kernel32::WriteConsoleA(stdout, msg.as_ptr() as *const winapi::VOID, msg.len() as winapi::DWORD, ptr::null_mut(), ptr::null_mut()) };
+#![feature(lang_items)]
+#![no_std]
+#![no_main]
+
+// Executables must define the `eh_personality` and `panic_fmt` lang items.
+// Normally libstd does this for us; however we only have libcore, and we don't
+// need or want the defaults anyway, since our code literally can't panic.
+
+#[lang = "eh_personality"]
+extern fn eh_personality() {}
+
+#[lang = "panic_fmt"]
+fn panic_fmt() -> ! {
+    loop {}
 }
-#[link(name = "ucrt")]
-#[link(name = "vcruntime")]
-extern {}
-#[no_mangle] pub extern "system" fn entry_point() { main() }
+
+// kernel32 FFI bindings.
+enum CVoid {}
+
+type BOOL    = i32;
+type DWORD   = u32;
+type LPDWORD = *mut DWORD;
+type HANDLE  = *mut CVoid;
+type VOID    = CVoid;
+type LPVOID  = *mut VOID;
+
+const STD_OUTPUT_HANDLE: DWORD = 0xfffffff4;
+
+#[link(name = "kernel32")]
+extern "system" {
+    fn GetStdHandle(nStdHandle: DWORD) -> HANDLE;
+    fn WriteConsoleA(
+        hConsoleOutput:         HANDLE,
+        lpBuffer:               *const VOID,
+        nNumberOfCharsToWrite:  DWORD,
+        lpNumberOfCharsWritten: LPDWORD,
+        lpReserved:             LPVOID
+    ) -> BOOL;
+}
+
+// Program entry point. Windows directly calls into this function - no shimming
+// shenanigans here!
+#[no_mangle] pub extern "system" fn entry_point() {
+    use core::ptr;
+    let msg = "Hello world!\n";
+    let stdout = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+    unsafe { WriteConsoleA(stdout, msg.as_ptr() as *const VOID, msg.len() as DWORD, ptr::null_mut(), ptr::null_mut()) };
+}


### PR DESCRIPTION
I've rewritten the Windows version to use `#![no_std]`, shaving off roughly 200 bytes.

Notes:
- `#![no_std]` executables are unstable, so this now requires nightly Rust for the time being.
- In line with the above, the Cargo dependencies on winapi and kernel32-sys had to be replaced with hand-written FFI bindings because they aren't `#![no_std]`, which caused rustc to pull in a ton of dependencies and then fail to build the executable anyway. It might be worth investigating if the winapi crates can be `#![no_std]`.
- `/SUBSYSTEM:CONSOLE /NODEFAULTLIB` now need to be passed to the linker. This removes dependencies on the CRT and other libraries that are normally linked in by default.
